### PR TITLE
serien.sx hinzufügen

### DIFF
--- a/blocked.md
+++ b/blocked.md
@@ -1,3 +1,5 @@
 http://s.to/
 
 http://serienstream.sx/
+
+http://serien.sx/


### PR DESCRIPTION
serien.sx ist eine alternative Domain zu s.to und ebenfalls seit kurzem gesperrt